### PR TITLE
[KAIZEN-0] oppdatert docker-image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM docker.pkg.github.com/navikt/modialogin/frontend:14e8e536f14ffd76fca3aedf6fdd711f624febc2
+FROM docker.pkg.github.com/navikt/modialogin/frontend:c04af997cb7e859a17422c2c7bae9cfdce76988f
 COPY build /app


### PR DESCRIPTION
skrur av loggene slik at vi unngår jwt i loggen mens vi finner en løsning