### PR TITLE
[PROD] [KAIZEN-0] bump host image

### DIFF
--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -46,6 +46,8 @@ spec:
       value: "https://isso.adeo.no/isso/oauth2/.well-known/openid-configuration"
     - name: IDP_CLIENT_ID
       value: "modialogin-p"
+    - name: IDP_ISSUER
+        value: "https://isso.adeo.no:443/isso/oauth2"
     - name: DELEGATED_LOGIN_URL
       value: "https://app.adeo.no/modialogin/api/start"
     - name: DELEGATED_REFRESH_URL

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -48,8 +48,12 @@ spec:
       value: "modialogin-p"
     - name: DELEGATED_LOGIN_URL
       value: "https://app.adeo.no/modialogin/api/start"
+    - name: DELEGATED_REFRESH_URL
+      value: "https://app.adeo.no/modialogin/api/refresh"
     - name: AUTH_TOKEN_RESOLVER
       value: "modia_ID_token"
+    - name: REFRESH_TOKEN_RESOLVER
+      value: "modia_refresh_token"
     - name: CSP_DIRECTIVES
       value: "default-src 'self';\
       script-src 'self' 'unsafe-inline';\

--- a/.nais/qa-template.yaml
+++ b/.nais/qa-template.yaml
@@ -43,6 +43,8 @@ spec:
       value: "https://isso-q.adeo.no/isso/oauth2/.well-known/openid-configuration"
     - name: IDP_CLIENT_ID
       value: "modialogin-{{ q_env }}"
+    - name: IDP_ISSUER
+      value: "https://isso-q.adeo.no:443/isso/oauth2"
     - name: DELEGATED_LOGIN_URL
       value: "https://app-{{ q_env }}.adeo.no/modialogin/api/start"
     - name: DELEGATED_REFRESH_URL

--- a/.nais/qa-template.yaml
+++ b/.nais/qa-template.yaml
@@ -45,8 +45,12 @@ spec:
       value: "modialogin-{{ q_env }}"
     - name: DELEGATED_LOGIN_URL
       value: "https://app-{{ q_env }}.adeo.no/modialogin/api/start"
+    - name: DELEGATED_REFRESH_URL
+      value: "https://app-{{ q_env }}.adeo.no/modialogin/api/refresh"
     - name: AUTH_TOKEN_RESOLVER
       value: "modia_ID_token"
+    - name: REFRESH_TOKEN_RESOLVER
+      value: "modia_refresh_token"
     - name: CSP_DIRECTIVES
       value: "default-src 'self';\
       script-src 'self' 'unsafe-inline';\

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM ghcr.io/navikt/modialogin/modialogin-frontend:f28754685871f1e0af83d3a0c5a6a3684a310aac-beta
+FROM ghcr.io/navikt/modialogin/modialogin-frontend:fc235a5e74a452fc372bb57a3dd498f21fcfb287-beta
 COPY build /www

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM ghcr.io/navikt/modialogin/modialogin-frontend:fc235a5e74a452fc372bb57a3dd498f21fcfb287-beta
+FROM ghcr.io/navikt/modialogin/modialogin-frontend:099a9a1ab44340afdf95514439672bf959708603-beta
 COPY build /www

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM ghcr.io/navikt/modialogin/modialogin-frontend:d8a85b849e50a2c57a4376b2fe6b67ecbdb2098d
+FROM ghcr.io/navikt/modialogin/modialogin-frontend:f28754685871f1e0af83d3a0c5a6a3684a310aac-beta
 COPY build /www

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM ghcr.io/navikt/modialogin/modialogin-frontend:099a9a1ab44340afdf95514439672bf959708603-beta
+FROM ghcr.io/navikt/modialogin/modialogin-frontend:43c212f28aaa1e720509ed8be19598da7c4795ee-beta
 COPY build /www


### PR DESCRIPTION
Host imaget har nå støtte for dobbel innlogging med openam og azuread:

- 5201cc7 [KAIZEN-0] bump host image
- 95637c1 [KAIZEN-0] bump host image
- 2f0a6d5 [KAIZEN-0] bump host image med idp-issuer konfig
- 242a36a [KAIZEN-0] legge til nye påkrevde felter for host image
- 034bd1a [KAIZEN-0] bump host image